### PR TITLE
feat: integrate openai streaming chat via SSE

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,5 @@ DB_USER=root
 DB_PASSWORD=tu_contraseña
 DB_NAME=nombre_base
 OPENAI_API_KEY=tu_api_key
+OPENAI_PROJECT_ID=tu_project_id
+CHAT_PRINCIPAL_ASSISTANT=tu_assistant_id

--- a/backend/chat/chat.go
+++ b/backend/chat/chat.go
@@ -1,0 +1,57 @@
+package chat
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"ema-backend/openai"
+	"ema-backend/sse"
+)
+
+type Handler struct {
+	AI *openai.Client
+}
+
+func NewHandler(ai *openai.Client) *Handler {
+	return &Handler{AI: ai}
+}
+
+func (h *Handler) Start(c *gin.Context) {
+	var req struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "prompt requerido"})
+		return
+	}
+	ch, err := h.AI.StreamMessage(c, req.Prompt)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	var sb strings.Builder
+	for token := range ch {
+		sb.WriteString(token)
+	}
+	c.JSON(http.StatusOK, gin.H{"thread_id": uuid.NewString(), "text": sb.String()})
+}
+
+func (h *Handler) Message(c *gin.Context) {
+	var req struct {
+		ThreadID string `json:"thread_id"`
+		Prompt   string `json:"prompt"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "parámetros inválidos"})
+		return
+	}
+	stream, err := h.AI.StreamMessage(c, req.Prompt)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	sse.Stream(c, stream)
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,8 @@ go 1.24.4
 require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-sql-driver/mysql v1.9.3
+	github.com/google/uuid v1.3.0
+	github.com/sashabaranov/go-openai v1.24.0
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -32,6 +32,8 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -51,6 +53,8 @@ github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sashabaranov/go-openai v1.24.0 h1:4H4Pg8Bl2RH/YSnU8DYumZbuHnnkfioor/dtNlB20D4=
+github.com/sashabaranov/go-openai v1.24.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"ema-backend/chat"
 	"ema-backend/login"
+	"ema-backend/openai"
 	"github.com/gin-gonic/gin"
 )
 
@@ -9,9 +11,12 @@ func main() {
 	r := gin.Default()
 
 	r.POST("/login", login.Handler)
-
 	r.GET("/session", login.SessionHandler)
 
+	ai := openai.NewClient()
+	chatHandler := chat.NewHandler(ai)
+	r.POST("/asistente/start", chatHandler.Start)
+	r.POST("/asistente/message", chatHandler.Message)
 
 	r.Run(":8080")
 }

--- a/backend/openai/client.go
+++ b/backend/openai/client.go
@@ -1,0 +1,50 @@
+package openai
+
+import (
+	"context"
+	"os"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type Client struct {
+	api         *openai.Client
+	AssistantID string
+}
+
+func NewClient() *Client {
+	key := os.Getenv("OPENAI_API_KEY")
+	assistant := os.Getenv("CHAT_PRINCIPAL_ASSISTANT")
+	c := openai.NewClient(key)
+	return &Client{api: c, AssistantID: assistant}
+}
+
+func (c *Client) StreamMessage(ctx context.Context, prompt string) (<-chan string, error) {
+	stream, err := c.api.CreateChatCompletionStream(ctx, openai.ChatCompletionRequest{
+		Model: c.AssistantID,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan string)
+
+	go func() {
+		defer stream.Close()
+		defer close(ch)
+		for {
+			resp, err := stream.Recv()
+			if err != nil {
+				break
+			}
+			if len(resp.Choices) > 0 {
+				ch <- resp.Choices[0].Delta.Content
+			}
+		}
+	}()
+
+	return ch, nil
+}

--- a/backend/sse/sse.go
+++ b/backend/sse/sse.go
@@ -1,0 +1,21 @@
+package sse
+
+import (
+	"io"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Stream(c *gin.Context, ch <-chan string) {
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Stream(func(w io.Writer) bool {
+		if msg, ok := <-ch; ok {
+			c.SSEvent("message", msg)
+			return true
+		}
+		c.SSEvent("message", "[DONE]")
+		return false
+	})
+}

--- a/lib/app/chat/controllers/chat_controller.dart
+++ b/lib/app/chat/controllers/chat_controller.dart
@@ -250,13 +250,23 @@ class ChatController extends GetxService {
 
       try {
         print('🚀 [ChatController] Enviando mensaje al servidor...');
-        final aiMessage = await chatsService.sendMessage(
-          threadId: threadId,
-          userMessage: userMessage,
-          file: currentPdf,
+        final aiMessage = ChatMessageModel.ai(
+          chatId: currentChat.value.uid,
+          text: '',
         );
         messages.add(aiMessage);
         scrollToBottom();
+        final response = await chatsService.sendMessage(
+          threadId: threadId,
+          userMessage: userMessage,
+          file: currentPdf,
+          onStream: (token) {
+            aiMessage.text += token;
+            messages.refresh();
+            scrollToBottom();
+          },
+        );
+        aiMessage.text = response.text;
         print('✅ [ChatController] Respuesta del servidor recibida');
 
         // Descontar la cuota después de enviar el archivo

--- a/lib/app/chat/interfaces/chat_interfaces.dart
+++ b/lib/app/chat/interfaces/chat_interfaces.dart
@@ -22,6 +22,7 @@ abstract class IApiChatData {
     required String threadId,
     required String prompt,
     CancelToken? cancelToken,
+    void Function(String token)? onStream,
   });
 
   Future<ChatMessageModel> sendPdfUpload({

--- a/lib/app/chat/services/chats_service.dart
+++ b/lib/app/chat/services/chats_service.dart
@@ -103,6 +103,7 @@ class ChatsService extends GetxService {
     required String threadId,
     required ChatMessageModel userMessage,
     PdfAttachment? file,
+    void Function(String token)? onStream,
   }) async {
     chatMessagesLocalData.insertOne(userMessage);
 
@@ -123,6 +124,7 @@ class ChatsService extends GetxService {
     final apiMessage = await apiChatService.sendMessage(
       threadId: threadId,
       prompt: userMessage.text,
+      onStream: onStream,
     );
     final aiMessage = ChatMessageModel.ai(
       chatId: userMessage.chatId,


### PR DESCRIPTION
## Summary
- add OpenAI client and SSE streaming backend endpoints
- stream assistant replies to frontend chat in real time
- document OpenAI env vars

## Testing
- `go build -v ./...`
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68998ee65458832a90d4f95db5a91278