### PR TITLE
feat: add quiz generation package

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -14,6 +14,7 @@ import (
 	"ema-backend/openai"
 	"ema-backend/profile"
 	"ema-backend/subscriptions"
+	"ema-backend/tests"
 
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
@@ -79,6 +80,12 @@ func main() {
 	chatHandler := chat.NewHandler(ai)
 	r.POST("/asistente/start", chatHandler.Start)
 	r.POST("/asistente/message", chatHandler.Message)
+
+	// Tests/quiz generation endpoints
+	quizAI := tests.NewQuizAI()
+	testRepo := tests.NewRepository(db)
+	testHandler := tests.NewHandler(testRepo, quizAI)
+	testHandler.RegisterRoutes(r)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/backend/migrations/migrations.go
+++ b/backend/migrations/migrations.go
@@ -67,10 +67,10 @@ func Migrate() error {
 		return err
 	}
 	createSubs := `
-	CREATE TABLE IF NOT EXISTS subscriptions (
-		id INT AUTO_INCREMENT PRIMARY KEY,
-		user_id INT NOT NULL,
-		plan_id INT NOT NULL,
+        CREATE TABLE IF NOT EXISTS subscriptions (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                user_id INT NOT NULL,
+                plan_id INT NOT NULL,
 		start_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		end_date DATETIME NULL,
 		frequency INT NOT NULL DEFAULT 0,
@@ -82,6 +82,33 @@ func Migrate() error {
 		FOREIGN KEY (plan_id) REFERENCES subscription_plans(id) ON DELETE CASCADE
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`
 	if _, err := db.Exec(createSubs); err != nil {
+		return err
+	}
+
+	createTests := `
+        CREATE TABLE IF NOT EXISTS tests (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                user_id INT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`
+	if _, err := db.Exec(createTests); err != nil {
+		return err
+	}
+
+	createTestQuestions := `
+        CREATE TABLE IF NOT EXISTS test_questions (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                test_id INT NOT NULL,
+                question TEXT NOT NULL,
+                answer TEXT NOT NULL,
+                type VARCHAR(50) NOT NULL,
+                options TEXT,
+                category VARCHAR(100),
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (test_id) REFERENCES tests(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`
+	if _, err := db.Exec(createTestQuestions); err != nil {
 		return err
 	}
 	return nil

--- a/backend/tests/agents.md
+++ b/backend/tests/agents.md
@@ -1,0 +1,20 @@
+# tests package: Quiz generation endpoints
+
+Overview
+- Provides HTTP endpoints to generate medical quizzes using OpenAI.
+- Persists generated quizzes and questions in MySQL.
+
+Environment variables
+- CUESTIONARIOS_MEDICOS_GENERALES: Assistant identifier used for quiz generation.
+
+How it works
+- POST /tests/generate/:userId: accepts {num_questions, nivel, id_categoria} and returns {success, data{test_id, thread_id, questions}}.
+- Uses openai client for LLM interaction and stores results via repository.
+
+Good practices
+- Validate input parameters.
+- Handle and log OpenAI/API errors gracefully.
+- Sanitize and parameterize SQL statements to avoid injection.
+
+Architecture notes
+- Repository wraps database operations; handler deals with HTTP and AI orchestration.

--- a/backend/tests/tests.go
+++ b/backend/tests/tests.go
@@ -1,0 +1,145 @@
+package tests
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"ema-backend/openai"
+)
+
+// Question represents a quiz question payload.
+type Question struct {
+	ID       int      `json:"id"`
+	Question string   `json:"question"`
+	Answer   string   `json:"answer"`
+	Type     string   `json:"type"`
+	Options  []string `json:"options"`
+	Category any      `json:"category"`
+}
+
+// Repository handles DB operations for tests.
+type Repository struct {
+	db *sql.DB
+}
+
+// NewRepository creates a new repository with the given DB.
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// CreateTest inserts a new test for a user and returns its ID.
+func (r *Repository) CreateTest(userID int) (int64, error) {
+	res, err := r.db.Exec("INSERT INTO tests (user_id) VALUES (?)", userID)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// InsertQuestion stores a question for the given test.
+func (r *Repository) InsertQuestion(testID int64, q Question) error {
+	opts, err := json.Marshal(q.Options)
+	if err != nil {
+		return err
+	}
+	_, err = r.db.Exec(`INSERT INTO test_questions (test_id, question, answer, type, options, category) VALUES (?,?,?,?,?,?)`, testID, q.Question, q.Answer, q.Type, string(opts), q.Category)
+	return err
+}
+
+// Handler exposes quiz endpoints.
+type Handler struct {
+	repo *Repository
+	ai   *openai.Client
+}
+
+// NewHandler constructs a Handler.
+func NewHandler(repo *Repository, ai *openai.Client) *Handler {
+	return &Handler{repo: repo, ai: ai}
+}
+
+// RegisterRoutes sets up HTTP routes for quizzes.
+func (h *Handler) RegisterRoutes(r *gin.Engine) {
+	r.POST("/tests/generate/:userId", h.Generate)
+}
+
+type generateReq struct {
+	NumQuestions int    `json:"num_questions"`
+	Nivel        string `json:"nivel"`
+	IdCategoria  []int  `json:"id_categoria"`
+}
+
+// Generate creates a quiz for a user and returns it in the expected JSON format.
+func (h *Handler) Generate(c *gin.Context) {
+	userID, err := strconv.Atoi(c.Param("userId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "usuario inválido"})
+		return
+	}
+	var req generateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "parámetros inválidos"})
+		return
+	}
+	prompt := fmt.Sprintf(`Crea un cuestionario de medicina interna.#las siguiente reglas deben ser tomadas en cuenta a la hora de generar el cuestionarioReglas:1. Formato de las preguntas:- Incluye 4 o 5 opciones, con una Única respuesta correcta.- Incluye preguntas de "excepto" y "sin excepto" según corresponda.
+
+Por favor, genera un JSON con un objeto que contenga las siguientes claves:
+"questions": Un array de objetos de preguntas de tamaño %d. Cada objeto debe contener:
+- "id": Un número entero acendente.
+- "question": El texto de la pregunta.
+- "answer": La respuesta correcta para la pregunta.
+- "type": El tipo de pregunta. Puede ser uno de los siguientes: "true_false", "open_ended", "single_choice".
+- "options": Solo para preguntas de tipo "single_choice", un array de opciones posibles.
+- "category": Puede ser null si no hay una categoría asignada.
+
+El numero de preguntas debe ser igual a la cantidad solicitada. Los tipos de pregunta deben ser seleccionados aleatoriamente entre los tres tipos disponibles: "true_false", "open_ended" y "single_choice".
+Responde estrictamente en formato JSON, sin texto adicional. Limita el contenido a medicina interna. El nivel de dificultad debe ser %s.`, req.NumQuestions, req.Nivel)
+
+	stream, err := h.ai.StreamMessage(c, prompt)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	var sb strings.Builder
+	for token := range stream {
+		sb.WriteString(token)
+	}
+	var payload struct {
+		Questions []Question `json:"questions"`
+	}
+	if err := json.Unmarshal([]byte(sb.String()), &payload); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "respuesta inválida"})
+		return
+	}
+	testID, err := h.repo.CreateTest(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "no se pudo crear el test"})
+		return
+	}
+	for _, q := range payload.Questions {
+		if err := h.repo.InsertQuestion(testID, q); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "no se pudo guardar la pregunta"})
+			return
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": gin.H{"test_id": testID, "thread_id": "", "questions": payload.Questions}})
+}
+
+// NewQuizAI returns an OpenAI client configured for quiz generation.
+func NewQuizAI() *openai.Client {
+	c := openai.NewClient()
+	if id := os.Getenv("CUESTIONARIOS_MEDICOS_GENERALES"); id != "" {
+		c.AssistantID = id
+	}
+	return c
+}


### PR DESCRIPTION
## Summary
- add `tests` package to generate quizzes with OpenAI and persist results
- create migrations for `tests` and `test_questions` tables
- wire quiz generation route into server startup
- configure quiz assistant ID via `CUESTIONARIOS_MEDICOS_GENERALES` env var

## Testing
- `(cd backend && go test ./...)`


------
https://chatgpt.com/codex/tasks/task_e_689a23a36e30832aa05bbbb2f4f77321